### PR TITLE
Make Writer public again.

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -5,7 +5,7 @@ import (
 	"net"
 )
 
-func (w writer) getDialer() func() (serverConn, string, error) {
+func (w Writer) getDialer() func() (serverConn, string, error) {
 	dialers := map[string]func() (serverConn, string, error){
 		"":        w.unixDialer,
 		"tcp+tls": w.tlsDialer,
@@ -17,7 +17,7 @@ func (w writer) getDialer() func() (serverConn, string, error) {
 	return dialer
 }
 
-func (w writer) unixDialer() (serverConn, string, error) {
+func (w Writer) unixDialer() (serverConn, string, error) {
 	sc, err := unixSyslog()
 	hostname := w.hostname
 	if hostname == "" {
@@ -26,7 +26,7 @@ func (w writer) unixDialer() (serverConn, string, error) {
 	return sc, hostname, err
 }
 
-func (w writer) tlsDialer() (serverConn, string, error) {
+func (w Writer) tlsDialer() (serverConn, string, error) {
 	c, err := tls.Dial("tcp", w.raddr, w.tlsConfig)
 	var sc serverConn
 	hostname := w.hostname
@@ -39,7 +39,7 @@ func (w writer) tlsDialer() (serverConn, string, error) {
 	return sc, hostname, err
 }
 
-func (w writer) basicDialer() (serverConn, string, error) {
+func (w Writer) basicDialer() (serverConn, string, error) {
 	c, err := net.Dial(w.network, w.raddr)
 	var sc serverConn
 	hostname := w.hostname

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGetDialer(t *testing.T) {
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "",
@@ -20,41 +20,41 @@ func TestGetDialer(t *testing.T) {
 
 	dialer := w.getDialer()
 	name := runtime.FuncForPC(reflect.ValueOf(dialer).Pointer()).Name()
-	if name != "github.com/RackSec/srslog.(writer).(github.com/RackSec/srslog.unixDialer)-fm" {
+	if name != "github.com/RackSec/srslog.(Writer).(github.com/RackSec/srslog.unixDialer)-fm" {
 		t.Errorf("should get unixDialer, got: %v", name)
 	}
 
 	w.network = "tcp+tls"
 	dialer = w.getDialer()
 	name = runtime.FuncForPC(reflect.ValueOf(dialer).Pointer()).Name()
-	if name != "github.com/RackSec/srslog.(writer).(github.com/RackSec/srslog.tlsDialer)-fm" {
+	if name != "github.com/RackSec/srslog.(Writer).(github.com/RackSec/srslog.tlsDialer)-fm" {
 		t.Errorf("should get tlsDialer, got: %v", name)
 	}
 
 	w.network = "tcp"
 	dialer = w.getDialer()
 	name = runtime.FuncForPC(reflect.ValueOf(dialer).Pointer()).Name()
-	if name != "github.com/RackSec/srslog.(writer).(github.com/RackSec/srslog.basicDialer)-fm" {
+	if name != "github.com/RackSec/srslog.(Writer).(github.com/RackSec/srslog.basicDialer)-fm" {
 		t.Errorf("should get basicDialer, got: %v", name)
 	}
 
 	w.network = "udp"
 	dialer = w.getDialer()
 	name = runtime.FuncForPC(reflect.ValueOf(dialer).Pointer()).Name()
-	if name != "github.com/RackSec/srslog.(writer).(github.com/RackSec/srslog.basicDialer)-fm" {
+	if name != "github.com/RackSec/srslog.(Writer).(github.com/RackSec/srslog.basicDialer)-fm" {
 		t.Errorf("should get basicDialer, got: %v", name)
 	}
 
 	w.network = "something else entirely"
 	dialer = w.getDialer()
 	name = runtime.FuncForPC(reflect.ValueOf(dialer).Pointer()).Name()
-	if name != "github.com/RackSec/srslog.(writer).(github.com/RackSec/srslog.basicDialer)-fm" {
+	if name != "github.com/RackSec/srslog.(Writer).(github.com/RackSec/srslog.basicDialer)-fm" {
 		t.Errorf("should get basicDialer, got: %v", name)
 	}
 }
 
 func TestUnixDialer(t *testing.T) {
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "",
@@ -100,7 +100,7 @@ func TestTLSDialer(t *testing.T) {
 		RootCAs: pool,
 	}
 
-	w := writer{
+	w := Writer{
 		priority:  LOG_ERR,
 		tag:       "tag",
 		hostname:  "",
@@ -137,7 +137,7 @@ func TestTCPDialer(t *testing.T) {
 	addr, sock, _ := startServer("tcp", "", done)
 	defer sock.Close()
 
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "",
@@ -173,7 +173,7 @@ func TestUDPDialer(t *testing.T) {
 	addr, sock, _ := startServer("udp", "", done)
 	defer sock.Close()
 
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "",

--- a/srslog.go
+++ b/srslog.go
@@ -20,22 +20,25 @@ type serverConn interface {
 }
 
 // New establishes a new connection to the system log daemon.  Each
-// write to the returned writer sends a log message with the given
+// write to the returned Writer sends a log message with the given
 // priority and prefix.
-func New(priority priority, tag string) (w *writer, err error) {
+func New(priority priority, tag string) (w *Writer, err error) {
 	return Dial("", "", priority, tag)
 }
 
 // Dial establishes a connection to a log daemon by connecting to
 // address raddr on the specified network.  Each write to the returned
-// writer sends a log message with the given facility, severity and
+// Writer sends a log message with the given facility, severity and
 // tag.
 // If network is empty, Dial will connect to the local syslog server.
-func Dial(network, raddr string, priority priority, tag string) (*writer, error) {
+func Dial(network, raddr string, priority priority, tag string) (*Writer, error) {
 	return DialWithTLSConfig(network, raddr, priority, tag, nil)
 }
 
-func DialWithTLSCertPath(network, raddr string, priority priority, tag, certPath string) (*writer, error) {
+// DialWithTLSCertPath establishes a secure connection to a log daemon by connecting to
+// address raddr on the specified network. It uses certPath to load TLS certificates and configure
+// the secure connection.
+func DialWithTLSCertPath(network, raddr string, priority priority, tag, certPath string) (*Writer, error) {
 	pool := x509.NewCertPool()
 	serverCert, err := ioutil.ReadFile(certPath)
 	if err != nil {
@@ -49,7 +52,9 @@ func DialWithTLSCertPath(network, raddr string, priority priority, tag, certPath
 	return DialWithTLSConfig(network, raddr, priority, tag, &config)
 }
 
-func DialWithTLSConfig(network, raddr string, priority priority, tag string, tlsConfig *tls.Config) (*writer, error) {
+// DialWithTLSConfig establishes a secure connection to a log daemon by connecting to
+// address raddr on the specified network. It uses tlsConfig to configure the secure connection.
+func DialWithTLSConfig(network, raddr string, priority priority, tag string, tlsConfig *tls.Config) (*Writer, error) {
 	if err := validatePriority(priority); err != nil {
 		return nil, err
 	}
@@ -59,7 +64,7 @@ func DialWithTLSConfig(network, raddr string, priority priority, tag string, tls
 	}
 	hostname, _ := os.Hostname()
 
-	w := &writer{
+	w := &Writer{
 		priority:  priority,
 		tag:       tag,
 		hostname:  hostname,

--- a/writer.go
+++ b/writer.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 )
 
-// A writer is a connection to a syslog server.
-type writer struct {
+// A Writer is a connection to a syslog server.
+type Writer struct {
 	sync.Mutex // guards conn
 
 	priority  priority
@@ -22,7 +22,7 @@ type writer struct {
 
 // connect makes a connection to the syslog server.
 // It must be called with w.mu held.
-func (w *writer) connect() (err error) {
+func (w *Writer) connect() (err error) {
 	if w.conn != nil {
 		// ignore err from close, it makes sense to continue anyway
 		w.conn.close()
@@ -43,12 +43,12 @@ func (w *writer) connect() (err error) {
 
 // Write sends a log message to the syslog daemon using the default priority
 // passed into `srslog.New` or the `srslog.Dial*` functions.
-func (w *writer) Write(b []byte) (int, error) {
+func (w *Writer) Write(b []byte) (int, error) {
 	return w.writeAndRetry(w.priority, string(b))
 }
 
 // Close closes a connection to the syslog daemon.
-func (w *writer) Close() error {
+func (w *Writer) Close() error {
 	w.Lock()
 	defer w.Unlock()
 
@@ -62,61 +62,61 @@ func (w *writer) Close() error {
 
 // Emerg logs a message with severity LOG_EMERG; this overrides the default
 // priority passed to `srslog.New` and the `srslog.Dial*` functions.
-func (w *writer) Emerg(m string) (err error) {
+func (w *Writer) Emerg(m string) (err error) {
 	_, err = w.writeAndRetry(LOG_EMERG, m)
 	return err
 }
 
 // Alert logs a message with severity LOG_ALERT; this overrides the default
 // priority passed to `srslog.New` and the `srslog.Dial*` functions.
-func (w *writer) Alert(m string) (err error) {
+func (w *Writer) Alert(m string) (err error) {
 	_, err = w.writeAndRetry(LOG_ALERT, m)
 	return err
 }
 
 // Crit logs a message with severity LOG_CRIT; this overrides the default
 // priority passed to `srslog.New` and the `srslog.Dial*` functions.
-func (w *writer) Crit(m string) (err error) {
+func (w *Writer) Crit(m string) (err error) {
 	_, err = w.writeAndRetry(LOG_CRIT, m)
 	return err
 }
 
 // Err logs a message with severity LOG_ERR; this overrides the default
 // priority passed to `srslog.New` and the `srslog.Dial*` functions.
-func (w *writer) Err(m string) (err error) {
+func (w *Writer) Err(m string) (err error) {
 	_, err = w.writeAndRetry(LOG_ERR, m)
 	return err
 }
 
 // Warning logs a message with severity LOG_WARNING; this overrides the default
 // priority passed to `srslog.New` and the `srslog.Dial*` functions.
-func (w *writer) Warning(m string) (err error) {
+func (w *Writer) Warning(m string) (err error) {
 	_, err = w.writeAndRetry(LOG_WARNING, m)
 	return err
 }
 
 // Notice logs a message with severity LOG_NOTICE; this overrides the default
 // priority passed to `srslog.New` and the `srslog.Dial*` functions.
-func (w *writer) Notice(m string) (err error) {
+func (w *Writer) Notice(m string) (err error) {
 	_, err = w.writeAndRetry(LOG_NOTICE, m)
 	return err
 }
 
 // Info logs a message with severity LOG_INFO; this overrides the default
 // priority passed to `srslog.New` and the `srslog.Dial*` functions.
-func (w *writer) Info(m string) (err error) {
+func (w *Writer) Info(m string) (err error) {
 	_, err = w.writeAndRetry(LOG_INFO, m)
 	return err
 }
 
 // Debug logs a message with severity LOG_DEBUG; this overrides the default
 // priority passed to `srslog.New` and the `srslog.Dial*` functions.
-func (w *writer) Debug(m string) (err error) {
+func (w *Writer) Debug(m string) (err error) {
 	_, err = w.writeAndRetry(LOG_DEBUG, m)
 	return err
 }
 
-func (w *writer) writeAndRetry(p priority, s string) (int, error) {
+func (w *Writer) writeAndRetry(p priority, s string) (int, error) {
 	pr := (w.priority & facilityMask) | (p & severityMask)
 
 	w.Lock()
@@ -135,7 +135,7 @@ func (w *writer) writeAndRetry(p priority, s string) (int, error) {
 
 // write generates and writes a syslog formatted string. The
 // format is as follows: <PRI>TIMESTAMP HOSTNAME TAG[PID]: MSG
-func (w *writer) write(p priority, msg string) (int, error) {
+func (w *Writer) write(p priority, msg string) (int, error) {
 	// ensure it ends in a \n
 	if !strings.HasSuffix(msg, "\n") {
 		msg += "\n"

--- a/writer_test.go
+++ b/writer_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestCloseNonOpenWriter(t *testing.T) {
-	w := writer{}
+	w := Writer{}
 
 	err := w.Close()
 	if err != nil {
@@ -14,7 +14,7 @@ func TestCloseNonOpenWriter(t *testing.T) {
 }
 
 func TestWriteAndRetryFails(t *testing.T) {
-	w := writer{network: "udp", raddr: "fakehost"}
+	w := Writer{network: "udp", raddr: "fakehost"}
 
 	n, err := w.writeAndRetry(LOG_ERR, "nope")
 	if err == nil {
@@ -31,7 +31,7 @@ func TestDebug(t *testing.T) {
 	defer sock.Close()
 	defer srvWG.Wait()
 
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "hostname",
@@ -62,7 +62,7 @@ func TestInfo(t *testing.T) {
 	defer sock.Close()
 	defer srvWG.Wait()
 
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "hostname",
@@ -93,7 +93,7 @@ func TestNotice(t *testing.T) {
 	defer sock.Close()
 	defer srvWG.Wait()
 
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "hostname",
@@ -124,7 +124,7 @@ func TestWarning(t *testing.T) {
 	defer sock.Close()
 	defer srvWG.Wait()
 
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "hostname",
@@ -155,7 +155,7 @@ func TestErr(t *testing.T) {
 	defer sock.Close()
 	defer srvWG.Wait()
 
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "hostname",
@@ -186,7 +186,7 @@ func TestCrit(t *testing.T) {
 	defer sock.Close()
 	defer srvWG.Wait()
 
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "hostname",
@@ -217,7 +217,7 @@ func TestAlert(t *testing.T) {
 	defer sock.Close()
 	defer srvWG.Wait()
 
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "hostname",
@@ -248,7 +248,7 @@ func TestEmerg(t *testing.T) {
 	defer sock.Close()
 	defer srvWG.Wait()
 
-	w := writer{
+	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",
 		hostname: "hostname",


### PR DESCRIPTION
Because this library is harder to use when the returned value by the
main functions is protected.

For example, you cannot do something as simple as this:

```go
  var writer *srslog.Writer
  var err error

  if secureConnection {
    writer, err = srslog.DialWithTLSCertPath(...)
  } else {
    writer, err = srslog.Dial(...)
  }
```

I've also added godoc to both TLS functions.

Signed-off-by: David Calavera <david.calavera@gmail.com>