### PR TITLE
Make Priority public again.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 )
 
-// The priority is a combination of the syslog facility and
+// Priority is a combination of the syslog facility and
 // severity. For example, LOG_ALERT | LOG_FTP sends an alert severity
 // message from the FTP facility. The default severity is LOG_EMERG;
 // the default facility is LOG_KERN.
-type priority int
+type Priority int
 
 const severityMask = 0x07
 const facilityMask = 0xf8
@@ -18,7 +18,7 @@ const (
 
 	// From /usr/include/sys/syslog.h.
 	// These are the same on Linux, BSD, and OS X.
-	LOG_EMERG priority = iota
+	LOG_EMERG Priority = iota
 	LOG_ALERT
 	LOG_CRIT
 	LOG_ERR
@@ -33,7 +33,7 @@ const (
 
 	// From /usr/include/sys/syslog.h.
 	// These are the same up to LOG_FTP on Linux, BSD, and OS X.
-	LOG_KERN priority = iota << 3
+	LOG_KERN Priority = iota << 3
 	LOG_USER
 	LOG_MAIL
 	LOG_DAEMON
@@ -59,7 +59,7 @@ const (
 	LOG_LOCAL7
 )
 
-func validatePriority(p priority) error {
+func validatePriority(p Priority) error {
 	if p < 0 || p > LOG_LOCAL7|LOG_DEBUG {
 		return errors.New("log/syslog: invalid priority")
 	} else {

--- a/net_conn.go
+++ b/net_conn.go
@@ -11,7 +11,7 @@ type netConn struct {
 	conn net.Conn
 }
 
-func (n *netConn) writeString(p priority, hostname, tag, msg string) error {
+func (n *netConn) writeString(p Priority, hostname, tag, msg string) error {
 	timestamp := time.Now().Format(time.RFC3339)
 	_, err := fmt.Fprintf(n.conn, "<%d>%s %s %s[%d]: %s",
 		p, timestamp, hostname,

--- a/srslog.go
+++ b/srslog.go
@@ -15,14 +15,14 @@ import (
 // return a type that satisfies this interface and simply calls the C
 // library syslog function.
 type serverConn interface {
-	writeString(p priority, hostname, tag, s string) error
+	writeString(p Priority, hostname, tag, s string) error
 	close() error
 }
 
 // New establishes a new connection to the system log daemon.  Each
 // write to the returned Writer sends a log message with the given
 // priority and prefix.
-func New(priority priority, tag string) (w *Writer, err error) {
+func New(priority Priority, tag string) (w *Writer, err error) {
 	return Dial("", "", priority, tag)
 }
 
@@ -31,14 +31,14 @@ func New(priority priority, tag string) (w *Writer, err error) {
 // Writer sends a log message with the given facility, severity and
 // tag.
 // If network is empty, Dial will connect to the local syslog server.
-func Dial(network, raddr string, priority priority, tag string) (*Writer, error) {
+func Dial(network, raddr string, priority Priority, tag string) (*Writer, error) {
 	return DialWithTLSConfig(network, raddr, priority, tag, nil)
 }
 
 // DialWithTLSCertPath establishes a secure connection to a log daemon by connecting to
 // address raddr on the specified network. It uses certPath to load TLS certificates and configure
 // the secure connection.
-func DialWithTLSCertPath(network, raddr string, priority priority, tag, certPath string) (*Writer, error) {
+func DialWithTLSCertPath(network, raddr string, priority Priority, tag, certPath string) (*Writer, error) {
 	pool := x509.NewCertPool()
 	serverCert, err := ioutil.ReadFile(certPath)
 	if err != nil {
@@ -54,7 +54,7 @@ func DialWithTLSCertPath(network, raddr string, priority priority, tag, certPath
 
 // DialWithTLSConfig establishes a secure connection to a log daemon by connecting to
 // address raddr on the specified network. It uses tlsConfig to configure the secure connection.
-func DialWithTLSConfig(network, raddr string, priority priority, tag string, tlsConfig *tls.Config) (*Writer, error) {
+func DialWithTLSConfig(network, raddr string, priority Priority, tag string, tlsConfig *tls.Config) (*Writer, error) {
 	if err := validatePriority(priority); err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func DialWithTLSConfig(network, raddr string, priority priority, tag string, tls
 // the system log service with the specified priority. The logFlag
 // argument is the flag set passed through to log.New to create
 // the Logger.
-func NewLogger(p priority, logFlag int) (*log.Logger, error) {
+func NewLogger(p Priority, logFlag int) (*log.Logger, error) {
 	s, err := New(p, "")
 	if err != nil {
 		return nil, err

--- a/srslog_test.go
+++ b/srslog_test.go
@@ -288,7 +288,7 @@ func check(t *testing.T, in, out string) {
 	}
 }
 
-func checkWithPriorityAndTag(t *testing.T, p priority, tag, hostname, in, out string) {
+func checkWithPriorityAndTag(t *testing.T, p Priority, tag, hostname, in, out string) {
 	tmpl := fmt.Sprintf("<%d>%%s %%s %s[%%d]: %s\n", p, tag, in)
 	var parsedHostname, timestamp string
 	var pid int
@@ -301,7 +301,7 @@ func checkWithPriorityAndTag(t *testing.T, p priority, tag, hostname, in, out st
 
 func TestWrite(t *testing.T) {
 	tests := []struct {
-		pri priority
+		pri Priority
 		pre string
 		msg string
 		exp string
@@ -342,7 +342,7 @@ func TestWrite(t *testing.T) {
 
 func TestTLSWrite(t *testing.T) {
 	tests := []struct {
-		pri priority
+		pri Priority
 		pre string
 		msg string
 		exp string

--- a/srslog_unix.go
+++ b/srslog_unix.go
@@ -31,7 +31,7 @@ type localConn struct {
 	conn net.Conn
 }
 
-func (n *localConn) writeString(p priority, hostname, tag, msg string) error {
+func (n *localConn) writeString(p Priority, hostname, tag, msg string) error {
 	// Compared to the network form at srslog.netConn, the changes are:
 	//	1. Use time.Stamp instead of time.RFC3339.
 	//	2. Drop the hostname field from the Fprintf.

--- a/writer.go
+++ b/writer.go
@@ -10,7 +10,7 @@ import (
 type Writer struct {
 	sync.Mutex // guards conn
 
-	priority  priority
+	priority  Priority
 	tag       string
 	hostname  string
 	network   string
@@ -116,7 +116,7 @@ func (w *Writer) Debug(m string) (err error) {
 	return err
 }
 
-func (w *Writer) writeAndRetry(p priority, s string) (int, error) {
+func (w *Writer) writeAndRetry(p Priority, s string) (int, error) {
 	pr := (w.priority & facilityMask) | (p & severityMask)
 
 	w.Lock()
@@ -135,7 +135,7 @@ func (w *Writer) writeAndRetry(p priority, s string) (int, error) {
 
 // write generates and writes a syslog formatted string. The
 // format is as follows: <PRI>TIMESTAMP HOSTNAME TAG[PID]: MSG
-func (w *Writer) write(p priority, msg string) (int, error) {
+func (w *Writer) write(p Priority, msg string) (int, error) {
 	// ensure it ends in a \n
 	if !strings.HasSuffix(msg, "\n") {
 		msg += "\n"


### PR DESCRIPTION
Like #5, making `priority` a protected type makes it impossible to use outside this package.

Signed-off-by: David Calavera <david.calavera@gmail.com>