### PR TITLE
Dial TLS using a cert directly, rather than requiring a file path.

### DIFF
--- a/srslog.go
+++ b/srslog.go
@@ -35,11 +35,19 @@ func Dial(network, raddr string, priority Priority, tag string) (*Writer, error)
 // address raddr on the specified network. It uses certPath to load TLS certificates and configure
 // the secure connection.
 func DialWithTLSCertPath(network, raddr string, priority Priority, tag, certPath string) (*Writer, error) {
-	pool := x509.NewCertPool()
 	serverCert, err := ioutil.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}
+
+	return DialWithTLSCert(network, raddr, priority, tag, serverCert)
+}
+
+// DialWIthTLSCert establishes a secure connection to a log daemon by connecting to
+// address raddr on the specified network. It uses serverCert to load a TLS certificate
+// and configure the secure connection.
+func DialWithTLSCert(network, raddr string, priority Priority, tag string, serverCert []byte) (*Writer, error) {
+	pool := x509.NewCertPool()
 	pool.AppendCertsFromPEM(serverCert)
 	config := tls.Config{
 		RootCAs: pool,


### PR DESCRIPTION
Someone* may want to store the certs in a database or pass them as a variable, rather than storing them onto the filesystem. This function allows that.

_* Me._