### PR TITLE
The Dialer tests passed on OS X but failed on Linux (Fedora 22).

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -3,11 +3,23 @@ package srslog
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"reflect"
+	"regexp"
 	"runtime"
 	"testing"
 )
+
+// match checks if the given function (f) is the one inside the function pointer
+// (name) which is read via runtime reflection. This is necessary because different
+// platforms have a different reflection path. (IE on OS X it starts with "github.com..."
+// but on Linux it has an absolute path, "/home/<username>/go/src/github.com...")
+func match(f, name string) bool {
+	re := fmt.Sprintf(".*github.com/RackSec/srslog\\.\\(Writer\\)\\.\\(.*github.com/RackSec/srslog.%v\\)-fm", f)
+	matched, _ := regexp.MatchString(re, name)
+	return matched
+}
 
 func TestGetDialer(t *testing.T) {
 	w := Writer{
@@ -20,35 +32,35 @@ func TestGetDialer(t *testing.T) {
 
 	dialer := w.getDialer()
 	name := runtime.FuncForPC(reflect.ValueOf(dialer).Pointer()).Name()
-	if name != "github.com/RackSec/srslog.(Writer).(github.com/RackSec/srslog.unixDialer)-fm" {
+	if !match("unixDialer", name) {
 		t.Errorf("should get unixDialer, got: %v", name)
 	}
 
 	w.network = "tcp+tls"
 	dialer = w.getDialer()
 	name = runtime.FuncForPC(reflect.ValueOf(dialer).Pointer()).Name()
-	if name != "github.com/RackSec/srslog.(Writer).(github.com/RackSec/srslog.tlsDialer)-fm" {
+	if !match("tlsDialer", name) {
 		t.Errorf("should get tlsDialer, got: %v", name)
 	}
 
 	w.network = "tcp"
 	dialer = w.getDialer()
 	name = runtime.FuncForPC(reflect.ValueOf(dialer).Pointer()).Name()
-	if name != "github.com/RackSec/srslog.(Writer).(github.com/RackSec/srslog.basicDialer)-fm" {
+	if !match("basicDialer", name) {
 		t.Errorf("should get basicDialer, got: %v", name)
 	}
 
 	w.network = "udp"
 	dialer = w.getDialer()
 	name = runtime.FuncForPC(reflect.ValueOf(dialer).Pointer()).Name()
-	if name != "github.com/RackSec/srslog.(Writer).(github.com/RackSec/srslog.basicDialer)-fm" {
+	if !match("basicDialer", name) {
 		t.Errorf("should get basicDialer, got: %v", name)
 	}
 
 	w.network = "something else entirely"
 	dialer = w.getDialer()
 	name = runtime.FuncForPC(reflect.ValueOf(dialer).Pointer()).Name()
-	if name != "github.com/RackSec/srslog.(Writer).(github.com/RackSec/srslog.basicDialer)-fm" {
+	if !match("basicDialer", name) {
 		t.Errorf("should get basicDialer, got: %v", name)
 	}
 }

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -4,19 +4,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
-	"reflect"
 	"testing"
 )
-
-// funcEquals checks if the two given functions are the same. This grabs the
-// function pointer of each of them and compares them. This seems to be a viable
-// way to work around the fact that Go does not have actual function equality.
-func funcEquals(f1, f2 interface{}) bool {
-	av := reflect.ValueOf(f1).Pointer()
-	bv := reflect.ValueOf(f2).Pointer()
-
-	return av == bv
-}
 
 func TestGetDialer(t *testing.T) {
 	w := Writer{
@@ -28,31 +17,31 @@ func TestGetDialer(t *testing.T) {
 	}
 
 	dialer := w.getDialer()
-	if !funcEquals(w.unixDialer, dialer) {
+	if "unixDialer" != dialer.Name {
 		t.Errorf("should get unixDialer, got: %v", dialer)
 	}
 
 	w.network = "tcp+tls"
 	dialer = w.getDialer()
-	if !funcEquals(w.tlsDialer, dialer) {
+	if "tlsDialer" != dialer.Name {
 		t.Errorf("should get tlsDialer, got: %v", dialer)
 	}
 
 	w.network = "tcp"
 	dialer = w.getDialer()
-	if !funcEquals(w.basicDialer, dialer) {
+	if "basicDialer" != dialer.Name {
 		t.Errorf("should get basicDialer, got: %v", dialer)
 	}
 
 	w.network = "udp"
 	dialer = w.getDialer()
-	if !funcEquals(w.basicDialer, dialer) {
+	if "basicDialer" != dialer.Name {
 		t.Errorf("should get basicDialer, got: %v", dialer)
 	}
 
 	w.network = "something else entirely"
 	dialer = w.getDialer()
-	if !funcEquals(w.basicDialer, dialer) {
+	if "basicDialer" != dialer.Name {
 		t.Errorf("should get basicDialer, got: %v", dialer)
 	}
 }

--- a/writer.go
+++ b/writer.go
@@ -32,7 +32,7 @@ func (w *Writer) connect() (err error) {
 	var conn serverConn
 	var hostname string
 	dialer := w.getDialer()
-	conn, hostname, err = dialer()
+	conn, hostname, err = dialer.Call()
 	if err == nil {
 		w.conn = conn
 		w.hostname = hostname


### PR DESCRIPTION
This should resolve that by using regexp to check into the function pointer gotten from runtime reflection.