### PR TITLE
Reconnect when server closes connection

### DIFF
--- a/net_conn.go
+++ b/net_conn.go
@@ -24,6 +24,11 @@ func (n *netConn) writeString(framer Framer, formatter Formatter, p Priority, ho
 	return err
 }
 
+// read bytes from the socket
+func (n *netConn) read(b []byte) (int, error) {
+	return n.conn.Read(b)
+}
+
 // close the network connection
 func (n *netConn) close() error {
 	return n.conn.Close()

--- a/srslog.go
+++ b/srslog.go
@@ -12,6 +12,7 @@ import (
 // and enables Solaris support (see syslog_unix.go).
 type serverConn interface {
 	writeString(framer Framer, formatter Formatter, p Priority, hostname, tag, s string) error
+	read(b []byte) (int, error)
 	close() error
 }
 

--- a/srslog_test.go
+++ b/srslog_test.go
@@ -567,6 +567,10 @@ func (c testLocalConn) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
+func (c testLocalConn) Read(b []byte) (int, error) {
+	return 0, nil
+}
+
 func (c testLocalConn) Close() error {
 	return nil
 }

--- a/srslog_unix.go
+++ b/srslog_unix.go
@@ -32,7 +32,7 @@ func unixSyslog() (conn serverConn, err error) {
 // localConn adheres to the serverConn interface, allowing us to send syslog
 // messages to the local syslog daemon over a Unix domain socket.
 type localConn struct {
-	conn io.WriteCloser
+	conn io.ReadWriteCloser
 }
 
 // writeString formats syslog messages using time.Stamp instead of time.RFC3339,
@@ -46,6 +46,11 @@ func (n *localConn) writeString(framer Framer, formatter Formatter, p Priority, 
 	}
 	_, err := n.conn.Write([]byte(framer(formatter(p, hostname, tag, msg))))
 	return err
+}
+
+// read bytes from the socket
+func (n *localConn) read(b []byte) (int, error) {
+	return n.conn.Read(b)
 }
 
 // close the (local) network connection

--- a/writer.go
+++ b/writer.go
@@ -17,8 +17,9 @@ type Writer struct {
 	framer    Framer
 	formatter Formatter
 
-	mu   sync.RWMutex // guards conn
-	conn serverConn
+	mu            sync.RWMutex // guards conn
+	conn          serverConn
+	needReconnect bool
 }
 
 // getConn provides access to the internal conn, protected by a mutex. The
@@ -53,6 +54,10 @@ func (w *Writer) connect() (serverConn, error) {
 	if err == nil {
 		w.setConn(conn)
 		w.hostname = hostname
+		w.setNeedReconnect(false)
+		if w.network == "tcp" || w.network == "tcp+tls" {
+			go w.checkForRemoteDisconnect()
+		}
 
 		return conn, nil
 	} else {
@@ -152,7 +157,8 @@ func (w *Writer) writeAndRetry(p Priority, s string) (int, error) {
 	pr := (w.priority & facilityMask) | (p & severityMask)
 
 	conn := w.getConn()
-	if conn != nil {
+	needReconnect := w.getNeedReconnect()
+	if conn != nil && !needReconnect {
 		if n, err := w.write(conn, pr, s); err == nil {
 			return n, err
 		}
@@ -181,4 +187,50 @@ func (w *Writer) write(conn serverConn, p Priority, msg string) (int, error) {
 	// bytes printed by Fprintf, because this must behave like
 	// an io.Writer.
 	return len(msg), nil
+}
+
+// checkForRemoteDisconnect attempts to read from the socket, because if that
+// fails we know the remote server has closed the connection and we're going to
+// want to reconnect before sending another message
+func (w *Writer) checkForRemoteDisconnect() {
+	// since we don't expect the server to send data back to us, this for
+	// loop should never execute more than once; just in case something
+	// strange happens, we'll be ready for it
+	for {
+		// we can use the conn from multiple goroutines at once, but we need
+		// to lock in order to get access to the variable itself
+		conn := w.getConn()
+
+		// if there is no conn, we will need to reconnect
+		if conn == nil {
+			w.setNeedReconnect(true)
+			return
+		}
+
+		// read is blocking, so this will hang until it either succeeds or
+		// fails; since syslog servers don't write back to us, we never
+		// expect this to succeed; but if it fails, it means the syslog server
+		// disconnected unexpectedly and we'll want to reconnect to it
+		b := make([]byte, 1)
+		_, err := conn.read(b)
+		if err != nil {
+			w.setNeedReconnect(true)
+			return
+		}
+	}
+}
+
+// setNeedReconnect updates our variable that keeps track of whether the
+// remote syslog server has unexpectedly closed the connection, and locks
+// the mutex to protect us from race conditions
+func (w *Writer) setNeedReconnect(needReconnect bool) {
+	w.mu.Lock()
+	w.needReconnect = needReconnect
+	w.mu.Unlock()
+}
+
+func (w *Writer) getNeedReconnect() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.needReconnect
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,8 +1,13 @@
 package srslog
 
 import (
+	"crypto/tls"
+	"io/ioutil"
+	"net"
+	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCloseNonOpenWriter(t *testing.T) {
@@ -24,6 +29,114 @@ func TestWriteAndRetryFails(t *testing.T) {
 	if n != 0 {
 		t.Errorf("should not write any bytes")
 	}
+}
+
+// Handle cases where a remote server hangs up (e.g. idle timeout),
+// without dropping logs.
+func _TestSocketClose(l net.Listener, w *Writer, t *testing.T) {
+	// This server closes the client connection after receiving one packet,
+	// and then listens for a second connection.
+	//
+	// We want to ensure that our writer reconnects after the socket is closed.
+	go func() {
+		c, err := l.Accept()
+		b := make([]byte, 256)
+		c.Read(b)
+		c.Close()
+
+		// net.Listener doesn't have SetDeadline, so do this more generically.
+		connectionWaiter := make(chan net.Conn, 1)
+		go func() {
+			cc, e := l.Accept()
+			if e != nil {
+				t.Errorf("error accepting connection: %v", e)
+				return
+			}
+
+			connectionWaiter <- cc
+		}()
+
+		select {
+		case c = <-connectionWaiter:
+
+		case <-time.After(50 * time.Millisecond):
+			t.Errorf("didn't get a reconnection: %v", err)
+			return
+		}
+
+		b = make([]byte, 256)
+		c.Read(b)
+		c.Close()
+	}()
+
+	_, err := w.connect()
+	if err != nil {
+		t.Errorf("failed connecting to server: %v", err)
+		return
+	}
+
+	w.Write([]byte("this is a test message"))
+	time.Sleep(10 * time.Millisecond)
+	w.Write([]byte("this is a test message"))
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestSocketCloseTCP(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Errorf("failed starting server: %v", err)
+		return
+	}
+
+	defer l.Close()
+
+	w := Writer{network: "tcp", raddr: l.Addr().String()}
+	_TestSocketClose(l, &w, t)
+}
+
+func TestSocketCloseTLS(t *testing.T) {
+	cert, err := tls.LoadX509KeyPair("test/cert.pem", "test/privkey.pem")
+	if err != nil {
+		t.Errorf("failed to load TLS keypair: %v", err)
+		return
+	}
+
+	config := tls.Config{Certificates: []tls.Certificate{cert}}
+
+	l, err := tls.Listen("tcp", "127.0.0.1:0", &config)
+	if err != nil {
+		t.Errorf("failed starting server: %v", err)
+		return
+	}
+
+	defer l.Close()
+
+	// Server's TLS cert is not valid, so skip verifying
+	w := Writer{network: "tcp+tls", raddr: l.Addr().String(), tlsConfig: &tls.Config{InsecureSkipVerify: true}}
+	_TestSocketClose(l, &w, t)
+}
+
+func TestSocketCloseUnix(t *testing.T) {
+	// use ioutil.TempFile to get a name that is unique
+	f, err := ioutil.TempFile("", "syslogtest")
+	if err != nil {
+		t.Errorf("TempFile: %v", err)
+		return
+	}
+	f.Close()
+	laddr := f.Name()
+	os.Remove(laddr)
+
+	l, err := net.Listen("unix", laddr)
+	if err != nil {
+		t.Errorf("failed starting server: %v", err)
+		return
+	}
+
+	defer l.Close()
+
+	w := Writer{network: "unix", raddr: laddr}
+	_TestSocketClose(l, &w, t)
 }
 
 func TestWriteFormatters(t *testing.T) {


### PR DESCRIPTION
Related issue: https://github.com/docker/docker/issues/21136

If a remote syslog server closes the connection, srslog ends up dropping log(s). When the connection has been closed, and the client tries to send a log, the `Conn::Write` "succeeds" (no error returned) but the log is not delivered because the socket was closed. A subsequent `Conn::Write` will return a "broken pipe" error, and `writeAndRetry` will correctly reconnect and deliver this second log.

I experienced this when sending logs to Papertrail, which has a 15 minute idle timeout on TCP connections. When my process idles for >15 minutes, and then starts writing again, logs appear in Papertrail but the first one (or possibly more than one) is dropped.

It seems there's no great way to detect an error when executing that first `Conn::Write`, it's just generally how TCP works ([discussion](http://stackoverflow.com/questions/15067286/golang-tcpconn-setwritedeadline-doesnt-seem-to-work-as-expected)). If we keep track of the socket's status (by polling `Conn::Read`) then we can pick up on the socket closure when it happens, and reconnect before writing more logs. I've added a test case which fails on the current release but passes with this PR. Any suggestions for an alternative approach would be appreciated.

Also, I have never worked in Go before, so please feel free to correct anything that's not idiomatic. This is based pretty closely off of similar logic in [remote_syslog2](https://github.com/papertrail/remote_syslog2).
