### PR TITLE
More granular locking around conn.

### DIFF
--- a/srslog.go
+++ b/srslog.go
@@ -77,7 +77,7 @@ func DialWithTLSConfig(network, raddr string, priority Priority, tag string, tls
 		tlsConfig: tlsConfig,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		return nil, err
 	}

--- a/srslog.go
+++ b/srslog.go
@@ -77,9 +77,6 @@ func DialWithTLSConfig(network, raddr string, priority Priority, tag string, tls
 		tlsConfig: tlsConfig,
 	}
 
-	w.Lock()
-	defer w.Unlock()
-
 	err := w.connect()
 	if err != nil {
 		return nil, err

--- a/writer.go
+++ b/writer.go
@@ -53,9 +53,11 @@ func (w *Writer) connect() (serverConn, error) {
 	if err == nil {
 		w.setConn(conn)
 		w.hostname = hostname
-	}
 
-	return conn, err
+		return conn, nil
+	} else {
+		return nil, err
+	}
 }
 
 // SetFormatter changes the formatter function for subsequent messages.

--- a/writer.go
+++ b/writer.go
@@ -24,7 +24,7 @@ type Writer struct {
 // getConn provides access to the internal conn, protected by a mutex. The
 // conn is threadsafe, so it can be used while unlocked, but we want to avoid
 // race conditions on grabbing a reference to it.
-func (w Writer) getConn() serverConn {
+func (w *Writer) getConn() serverConn {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	return w.conn

--- a/writer_test.go
+++ b/writer_test.go
@@ -52,7 +52,7 @@ func TestWriteFormatters(t *testing.T) {
 			raddr:    addr,
 		}
 
-		err := w.connect()
+		_, err := w.connect()
 		if err != nil {
 			t.Errorf("failed to connect: %v", err)
 		}
@@ -101,7 +101,7 @@ func TestWriterFramers(t *testing.T) {
 			raddr:    addr,
 		}
 
-		err := w.connect()
+		_, err := w.connect()
 		if err != nil {
 			t.Errorf("failed to connect: %v", err)
 		}
@@ -140,7 +140,7 @@ func TestWriteWithDefaultPriority(t *testing.T) {
 		raddr:    addr,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestWriteWithProvidedPriority(t *testing.T) {
 		raddr:    addr,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestDebug(t *testing.T) {
 		raddr:    addr,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestInfo(t *testing.T) {
 		raddr:    addr,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestNotice(t *testing.T) {
 		raddr:    addr,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestWarning(t *testing.T) {
 		raddr:    addr,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestErr(t *testing.T) {
 		raddr:    addr,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestCrit(t *testing.T) {
 		raddr:    addr,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestAlert(t *testing.T) {
 		raddr:    addr,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
 	}
@@ -400,7 +400,7 @@ func TestEmerg(t *testing.T) {
 		raddr:    addr,
 	}
 
-	err := w.connect()
+	_, err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -52,13 +52,10 @@ func TestWriteFormatters(t *testing.T) {
 			raddr:    addr,
 		}
 
-		w.Lock()
 		err := w.connect()
 		if err != nil {
 			t.Errorf("failed to connect: %v", err)
-			w.Unlock()
 		}
-		w.Unlock()
 		defer w.Close()
 
 		w.SetFormatter(test.f)
@@ -104,13 +101,10 @@ func TestWriterFramers(t *testing.T) {
 			raddr:    addr,
 		}
 
-		w.Lock()
 		err := w.connect()
 		if err != nil {
 			t.Errorf("failed to connect: %v", err)
-			w.Unlock()
 		}
-		w.Unlock()
 		defer w.Close()
 
 		w.SetFramer(test.f)
@@ -146,13 +140,10 @@ func TestWriteWithDefaultPriority(t *testing.T) {
 		raddr:    addr,
 	}
 
-	w.Lock()
 	err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
-		w.Unlock()
 	}
-	w.Unlock()
 	defer w.Close()
 
 	var bytes int
@@ -181,13 +172,10 @@ func TestWriteWithProvidedPriority(t *testing.T) {
 		raddr:    addr,
 	}
 
-	w.Lock()
 	err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
-		w.Unlock()
 	}
-	w.Unlock()
 	defer w.Close()
 
 	var bytes int
@@ -216,13 +204,10 @@ func TestDebug(t *testing.T) {
 		raddr:    addr,
 	}
 
-	w.Lock()
 	err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
-		w.Unlock()
 	}
-	w.Unlock()
 	defer w.Close()
 
 	err = w.Debug("this is a test message")
@@ -247,13 +232,10 @@ func TestInfo(t *testing.T) {
 		raddr:    addr,
 	}
 
-	w.Lock()
 	err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
-		w.Unlock()
 	}
-	w.Unlock()
 	defer w.Close()
 
 	err = w.Info("this is a test message")
@@ -278,13 +260,10 @@ func TestNotice(t *testing.T) {
 		raddr:    addr,
 	}
 
-	w.Lock()
 	err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
-		w.Unlock()
 	}
-	w.Unlock()
 	defer w.Close()
 
 	err = w.Notice("this is a test message")
@@ -309,13 +288,10 @@ func TestWarning(t *testing.T) {
 		raddr:    addr,
 	}
 
-	w.Lock()
 	err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
-		w.Unlock()
 	}
-	w.Unlock()
 	defer w.Close()
 
 	err = w.Warning("this is a test message")
@@ -340,13 +316,10 @@ func TestErr(t *testing.T) {
 		raddr:    addr,
 	}
 
-	w.Lock()
 	err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
-		w.Unlock()
 	}
-	w.Unlock()
 	defer w.Close()
 
 	err = w.Err("this is a test message")
@@ -371,13 +344,10 @@ func TestCrit(t *testing.T) {
 		raddr:    addr,
 	}
 
-	w.Lock()
 	err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
-		w.Unlock()
 	}
-	w.Unlock()
 	defer w.Close()
 
 	err = w.Crit("this is a test message")
@@ -402,13 +372,10 @@ func TestAlert(t *testing.T) {
 		raddr:    addr,
 	}
 
-	w.Lock()
 	err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
-		w.Unlock()
 	}
-	w.Unlock()
 	defer w.Close()
 
 	err = w.Alert("this is a test message")
@@ -433,13 +400,10 @@ func TestEmerg(t *testing.T) {
 		raddr:    addr,
 	}
 
-	w.Lock()
 	err := w.connect()
 	if err != nil {
 		t.Errorf("failed to connect: %v", err)
-		w.Unlock()
 	}
-	w.Unlock()
 	defer w.Close()
 
 	err = w.Emerg("this is a test message")


### PR DESCRIPTION
We had been holding the lock open too long (even during network writes!) which left us open to potential deadlocks.

Additionally, it had been the responsibility of `connect`'s _caller_ to manage the lock, which is less than ideal.

Now we're only holding a lock long enough to get access to the `conn`, and relying on it to be threadsafe itself. We're never holding the lock during a network write. Callers don't have to manage the lock, it's handled within `getConn`/`setConn` (of course that means you _must_ grab the `conn` through those functions, as opposed to directly).

Finally, moving the mutex back to a private field within `Writer` instead of on the entire struct, because callers shouldn't have to deal with locking.