### PR TITLE
Don't use defer in hot path.

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -26,8 +26,9 @@ type Writer struct {
 // race conditions on grabbing a reference to it.
 func (w *Writer) getConn() serverConn {
 	w.mu.RLock()
-	defer w.mu.RUnlock()
-	return w.conn
+	conn := w.conn
+	w.mu.RUnlock()
+	return conn
 }
 
 // setConn updates the internal conn, protected by a mutex.


### PR DESCRIPTION
Since `writeAndRetry` winds up calling `getConn`, this puts `getConn` in
a hot path, where `defer` adds lots of undesirable overhead anytime
someone wants to write a log message.