### PR TITLE
Allow setting of facility when using WriteWithPriority

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -179,6 +179,38 @@ func TestWriteWithPriority(t *testing.T) {
 	defer w.Close()
 
 	var bytes int
+	bytes, err = w.WriteWithPriority(LOG_DEBUG, []byte("this is a test message"))
+	if err != nil {
+		t.Errorf("failed to write: %v", err)
+	}
+	if bytes == 0 {
+		t.Errorf("zero bytes written")
+	}
+
+	checkWithPriorityAndTag(t, LOG_DEBUG, "tag", "hostname", "this is a test message", <-done)
+}
+
+func TestWriteWithPriorityAndFacility(t *testing.T) {
+	done := make(chan string)
+	addr, sock, srvWG := startServer("udp", "", done)
+	defer sock.Close()
+	defer srvWG.Wait()
+
+	w := Writer{
+		priority: LOG_ERR,
+		tag:      "tag",
+		hostname: "hostname",
+		network:  "udp",
+		raddr:    addr,
+	}
+
+	_, err := w.connect()
+	if err != nil {
+		t.Errorf("failed to connect: %v", err)
+	}
+	defer w.Close()
+
+	var bytes int
 	bytes, err = w.WriteWithPriority(LOG_DEBUG|LOG_LOCAL5, []byte("this is a test message"))
 	if err != nil {
 		t.Errorf("failed to write: %v", err)

--- a/writer_test.go
+++ b/writer_test.go
@@ -158,7 +158,7 @@ func TestWriteWithDefaultPriority(t *testing.T) {
 	checkWithPriorityAndTag(t, LOG_ERR, "tag", "hostname", "this is a test message", <-done)
 }
 
-func TestWriteWithProvidedPriority(t *testing.T) {
+func TestWriteWithPriority(t *testing.T) {
 	done := make(chan string)
 	addr, sock, srvWG := startServer("udp", "", done)
 	defer sock.Close()
@@ -179,7 +179,7 @@ func TestWriteWithProvidedPriority(t *testing.T) {
 	defer w.Close()
 
 	var bytes int
-	bytes, err = w.WriteWithPriority(LOG_DEBUG, []byte("this is a test message"))
+	bytes, err = w.WriteWithPriority(LOG_DEBUG|LOG_LOCAL5, []byte("this is a test message"))
 	if err != nil {
 		t.Errorf("failed to write: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestWriteWithProvidedPriority(t *testing.T) {
 		t.Errorf("zero bytes written")
 	}
 
-	checkWithPriorityAndTag(t, LOG_DEBUG, "tag", "hostname", "this is a test message", <-done)
+	checkWithPriorityAndTag(t, LOG_DEBUG|LOG_LOCAL5, "tag", "hostname", "this is a test message", <-done)
 }
 
 func TestDebug(t *testing.T) {


### PR DESCRIPTION
Currently, it is not possible to set the facility. Given that the method is called "WithPriority" rather than "WithSeverity", I believe it would be most correct to allow setting of the facility.

I also noticed that there are a number of unnecessary conversions of `[]byte` to `string` when using the `Write*` methods of this library, causing unnecessary allocations. Would you be open to a separate PR to reduce these?