### PR TITLE
Add logger style formatting

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -46,3 +46,8 @@ func RFC5424Formatter(p Priority, hostname, tag, content string) string {
 		p, 1, timestamp, hostname, appName, pid, tag, content)
 	return msg
 }
+func LoggerFormatter(p Priority, hostname, tag, content string) string {
+    msg := fmt.Sprintf("<%d>%s: %s",
+        p, tag, content)
+    return msg
+}


### PR DESCRIPTION
If I run `logger -p local1.crit -t "cray" "ooooh noooo"` I get a log format like `Nov  9 19:08:19 smpp-05a cray: ooooh noooo` in /var/log/messages. So I have added this format as a choice.