### PR TITLE
For RFC5424 APP-NAME is limited to 48 chars - so truncate it

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -12,7 +12,6 @@ type Priority int
 
 const severityMask = 0x07
 const facilityMask = 0xf8
-const appNameMax = 48 // limit to 48 chars as per RFC5424
 
 const (
 	// Severity.

--- a/constants.go
+++ b/constants.go
@@ -12,6 +12,7 @@ type Priority int
 
 const severityMask = 0x07
 const facilityMask = 0xf8
+const appNameMax = 48 // limit to 48 chars as per RFC5424
 
 const (
 	// Severity.

--- a/formatter.go
+++ b/formatter.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const appNameMaxLength = 48 // limit to 48 chars as per RFC5424
+
 // Formatter is a type of function that takes the consituent parts of a
 // syslog message and returns a formatted string. A different Formatter is
 // defined for each different syslog protocol we support.
@@ -38,7 +40,7 @@ func RFC3164Formatter(p Priority, hostname, tag, content string) string {
 }
 
 // if string's length is greater than max, then use the last part
-func TruncateStartStr(s string, max int) string {
+func truncateStartStr(s string, max int) string {
 	if (len(s) > max) {
 		return s[len(s) - max:]
 	}
@@ -49,7 +51,7 @@ func TruncateStartStr(s string, max int) string {
 func RFC5424Formatter(p Priority, hostname, tag, content string) string {
 	timestamp := time.Now().Format(time.RFC3339)
 	pid := os.Getpid()
-	appName := TruncateStartStr(os.Args[0], appNameMax)
+	appName := truncateStartStr(os.Args[0], appNameMaxLength)
 	msg := fmt.Sprintf("<%d>%d %s %s %s %d %s - %s",
 		p, 1, timestamp, hostname, appName, pid, tag, content)
 	return msg

--- a/formatter.go
+++ b/formatter.go
@@ -42,6 +42,9 @@ func RFC5424Formatter(p Priority, hostname, tag, content string) string {
 	timestamp := time.Now().Format(time.RFC3339)
 	pid := os.Getpid()
 	appName := os.Args[0]
+	if (len(appName) > appNameMax) {
+		appName = appName[len(appName)-appNameMax:] // limit to appNameMax chars as per RFC5424
+	}
 	msg := fmt.Sprintf("<%d>%d %s %s %s %d %s - %s",
 		p, 1, timestamp, hostname, appName, pid, tag, content)
 	return msg

--- a/formatter.go
+++ b/formatter.go
@@ -37,14 +37,19 @@ func RFC3164Formatter(p Priority, hostname, tag, content string) string {
 	return msg
 }
 
+// if string's length is greater than max, then use the last part
+func TruncateStartStr(s string, max int) string {
+	if (len(s) > max) {
+		return s[len(s) - max:]
+	}
+	return s
+}
+
 // RFC5424Formatter provides an RFC 5424 compliant message.
 func RFC5424Formatter(p Priority, hostname, tag, content string) string {
 	timestamp := time.Now().Format(time.RFC3339)
 	pid := os.Getpid()
-	appName := os.Args[0]
-	if (len(appName) > appNameMax) {
-		appName = appName[len(appName)-appNameMax:] // limit to appNameMax chars as per RFC5424
-	}
+	appName := TruncateStartStr(os.Args[0], appNameMax)
 	msg := fmt.Sprintf("<%d>%d %s %s %s %d %s - %s",
 		p, 1, timestamp, hostname, appName, pid, tag, content)
 	return msg

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 	"time"
+	"strings"
 )
 
 func TestDefaultFormatter(t *testing.T) {
@@ -37,8 +38,20 @@ func TestRFC3164Formatter(t *testing.T) {
 func TestRFC5424Formatter(t *testing.T) {
 	out := RFC5424Formatter(LOG_ERR, "hostname", "tag", "content")
 	expected := fmt.Sprintf("<%d>%d %s %s %s %d %s - %s",
-		LOG_ERR, 1, time.Now().Format(time.RFC3339), "hostname", os.Args[0], os.Getpid(), "tag", "content")
+		LOG_ERR, 1, time.Now().Format(time.RFC3339), "hostname", TruncateStartStr(os.Args[0], appNameMax),
+			os.Getpid(), "tag", "content")
 	if out != expected {
 		t.Errorf("expected %v got %v", expected, out)
+	}
+}
+
+func TestTruncateStartStr(t *testing.T) {
+	out := TruncateStartStr("abcde", 3)
+	if strings.Compare(out, "cde" ) != 0 {
+		t.Errorf("expected \"cde\" got %v", out)
+	}
+	out = TruncateStartStr("abcde", 5)
+	if strings.Compare(out, "abcde" ) != 0 {
+		t.Errorf("expected \"abcde\" got %v", out)
 	}
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -38,7 +38,7 @@ func TestRFC3164Formatter(t *testing.T) {
 func TestRFC5424Formatter(t *testing.T) {
 	out := RFC5424Formatter(LOG_ERR, "hostname", "tag", "content")
 	expected := fmt.Sprintf("<%d>%d %s %s %s %d %s - %s",
-		LOG_ERR, 1, time.Now().Format(time.RFC3339), "hostname", TruncateStartStr(os.Args[0], appNameMax),
+		LOG_ERR, 1, time.Now().Format(time.RFC3339), "hostname", truncateStartStr(os.Args[0], appNameMaxLength),
 			os.Getpid(), "tag", "content")
 	if out != expected {
 		t.Errorf("expected %v got %v", expected, out)
@@ -46,11 +46,11 @@ func TestRFC5424Formatter(t *testing.T) {
 }
 
 func TestTruncateStartStr(t *testing.T) {
-	out := TruncateStartStr("abcde", 3)
+	out := truncateStartStr("abcde", 3)
 	if strings.Compare(out, "cde" ) != 0 {
 		t.Errorf("expected \"cde\" got %v", out)
 	}
-	out = TruncateStartStr("abcde", 5)
+	out = truncateStartStr("abcde", 5)
 	if strings.Compare(out, "abcde" ) != 0 {
 		t.Errorf("expected \"abcde\" got %v", out)
 	}


### PR DESCRIPTION
APP-NAME        = NILVALUE / 1*48PRINTUSASCII
Keep the last 48 chars as that is more interesting generally.
Could use elipsis truncating but then lose information - not sure if
worth it.