### PR TITLE
Add custom dialer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ w.Debug("this is debug")
 w.Write([]byte("these are some bytes"))
 ```
 
+If you need further control over connection attempts, you can use the DialWithCustomDialer
+function. To continue with the DialWithTLSConfig example:
+
+```
+netDialer := &net.Dialer{Timeout: time.Second*5} // easy timeouts
+realNetwork := "tcp" // real network, other vars your dail func can close over
+dial := func(network, addr string) (net.Conn, error) {
+    // cannot use "network" here as it'll simply be "custom" which will fail
+    return tls.DialWithDialer(netDialer, realNetwork, addr, &config)
+}
+
+w, err := DialWithCustomDialer("custom", "192.168.0.52:514", syslog.LOG_ERR, "testtag", dial)
+```
+
+Your custom dial func can set timeouts, proxy connections, and do whatever else it needs before returning a net.Conn.
+
 # Generating TLS Certificates
 
 We've provided a script that you can use to generate a self-signed keypair:

--- a/dialer.go
+++ b/dialer.go
@@ -34,15 +34,10 @@ func (df dialerFunctionWrapper) Call() (serverConn, string, error) {
 // value), and adding a new network type is as easy as writing the dialer
 // function and adding it to the map.
 func (w *Writer) getDialer() dialerFunctionWrapper {
-	if w.customDial != nil {
-		// we use 'customDialer' as the name, since the custom dialer can technically
-		// override any network we pass in anyways
-		return dialerFunctionWrapper{"customDialer", w.customDialer}
-	}
-
 	dialers := map[string]dialerFunctionWrapper{
 		"":        dialerFunctionWrapper{"unixDialer", w.unixDialer},
 		"tcp+tls": dialerFunctionWrapper{"tlsDialer", w.tlsDialer},
+		"custom":  dialerFunctionWrapper{"customDialer", w.customDialer},
 	}
 	dialer, ok := dialers[w.network]
 	if !ok {

--- a/dialer.go
+++ b/dialer.go
@@ -34,7 +34,7 @@ func (df dialerFunctionWrapper) Call() (serverConn, string, error) {
 // value), and adding a new network type is as easy as writing the dialer
 // function and adding it to the map.
 func (w *Writer) getDialer() dialerFunctionWrapper {
-	if w.cdialer != nil {
+	if w.customDial != nil {
 		// we use 'customDialer' as the name, since the custom dialer can technically
 		// override any network we pass in anyways
 		return dialerFunctionWrapper{"customDialer", w.customDialer}
@@ -96,7 +96,7 @@ func (w *Writer) basicDialer() (serverConn, string, error) {
 // giving developers total control over how connections are made and returned.
 // Note it does not check if cdialer is nil, as it should only be referenced from getDialer.
 func (w *Writer) customDialer() (serverConn, string, error) {
-	c, err := w.cdialer(w.network, w.raddr)
+	c, err := w.customDial(w.network, w.raddr)
 	var sc serverConn
 	hostname := w.hostname
 	if err == nil {

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -47,6 +47,7 @@ func TestGetDialer(t *testing.T) {
 		t.Errorf("should get basicDialer, got: %v", dialer)
 	}
 
+	w.network = "custom"
 	w.customDial = func(string, string) (net.Conn, error) { return nil, nil }
 	dialer = w.getDialer()
 	if "customDialer" != dialer.Name {
@@ -209,10 +210,7 @@ func TestCustomDialer(t *testing.T) {
 	// A custom dialer can really be anything, so we don't test an actual connection
 	// instead we test the behavior of this code path
 
-	// a dialer implementation may still consult the passed network and address
-	// so make sure we don't change them before being passed in
-
-	nwork, addr := "custom_network_to_pass", "custom_addr_to_pass"
+	nwork, addr := "custom", "custom_addr_to_pass"
 	w := Writer{
 		priority: LOG_ERR,
 		tag:      "tag",

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -47,7 +47,7 @@ func TestGetDialer(t *testing.T) {
 		t.Errorf("should get basicDialer, got: %v", dialer)
 	}
 
-	w.cdialer = func(string, string) (net.Conn, error) { return nil, nil }
+	w.customDial = func(string, string) (net.Conn, error) { return nil, nil }
 	dialer = w.getDialer()
 	if "customDialer" != dialer.Name {
 		t.Errorf("should get customDialer, got: %v", dialer)
@@ -219,7 +219,7 @@ func TestCustomDialer(t *testing.T) {
 		hostname: "",
 		network:  nwork,
 		raddr:    addr,
-		cdialer: func(n string, a string) (net.Conn, error) {
+		customDial: func(n string, a string) (net.Conn, error) {
 			if n != nwork || a != addr {
 				return nil, errors.New("Unexpected network or address, expected: (" +
 					nwork + ":" + addr + ") but received (" + n + ":" + a + ")")

--- a/srslog.go
+++ b/srslog.go
@@ -3,6 +3,7 @@ package srslog
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net"
@@ -36,11 +37,18 @@ func Dial(network, raddr string, priority Priority, tag string) (*Writer, error)
 	return DialWithTLSConfig(network, raddr, priority, tag, nil)
 }
 
+// ErrNilDialFunc is returned from DialWithCustomDialer when a nil DialFunc is passed,
+// avoiding a nil pointer deference panic.
+var ErrNilDialFunc = errors.New("srslog: nil DialFunc passed to DialWithCustomDialer")
+
 // DialWithCustomDialer establishes a connection by calling customDial.
 // Each write to the returned Writer sends a log message with the given facility, severity and tag.
 // While network and raddr will be passed to customDial, it is allowed for customDial to ignore them.
-// If customDial is nil, this function behaves like Dial.
+// If customDial is nil, this function returns ErrNilDialFunc.
 func DialWithCustomDialer(network, raddr string, priority Priority, tag string, customDial DialFunc) (*Writer, error) {
+	if customDial == nil {
+		return nil, ErrNilDialFunc
+	}
 	return dialAllParameters(network, raddr, priority, tag, nil, customDial)
 }
 

--- a/srslog.go
+++ b/srslog.go
@@ -43,6 +43,7 @@ var ErrNilDialFunc = errors.New("srslog: nil DialFunc passed to DialWithCustomDi
 
 // DialWithCustomDialer establishes a connection by calling customDial.
 // Each write to the returned Writer sends a log message with the given facility, severity and tag.
+// Network must be "custom" in order for this package to use customDial.
 // While network and raddr will be passed to customDial, it is allowed for customDial to ignore them.
 // If customDial is nil, this function returns ErrNilDialFunc.
 func DialWithCustomDialer(network, raddr string, priority Priority, tag string, customDial DialFunc) (*Writer, error) {

--- a/srslog.go
+++ b/srslog.go
@@ -83,13 +83,13 @@ func dialAllParameters(network, raddr string, priority Priority, tag string, tls
 	hostname, _ := os.Hostname()
 
 	w := &Writer{
-		priority:  priority,
-		tag:       tag,
-		hostname:  hostname,
-		network:   network,
-		raddr:     raddr,
-		tlsConfig: tlsConfig,
-		cdialer:   cdialer,
+		priority:   priority,
+		tag:        tag,
+		hostname:   hostname,
+		network:    network,
+		raddr:      raddr,
+		tlsConfig:  tlsConfig,
+		customDial: cdialer,
 	}
 
 	_, err := w.connect()

--- a/writer.go
+++ b/writer.go
@@ -2,6 +2,7 @@ package srslog
 
 import (
 	"crypto/tls"
+	"net"
 	"strings"
 	"sync"
 )
@@ -16,6 +17,9 @@ type Writer struct {
 	tlsConfig *tls.Config
 	framer    Framer
 	formatter Formatter
+
+	//non-nil if custom dialer set, used in getDialer
+	cdialer func(string, string) (net.Conn, error)
 
 	mu   sync.RWMutex // guards conn
 	conn serverConn

--- a/writer.go
+++ b/writer.go
@@ -2,7 +2,6 @@ package srslog
 
 import (
 	"crypto/tls"
-	"net"
 	"strings"
 	"sync"
 )
@@ -19,7 +18,7 @@ type Writer struct {
 	formatter Formatter
 
 	//non-nil if custom dialer set, used in getDialer
-	customDial func(string, string) (net.Conn, error)
+	customDial DialFunc
 
 	mu   sync.RWMutex // guards conn
 	conn serverConn

--- a/writer.go
+++ b/writer.go
@@ -19,7 +19,7 @@ type Writer struct {
 	formatter Formatter
 
 	//non-nil if custom dialer set, used in getDialer
-	cdialer func(string, string) (net.Conn, error)
+	customDial func(string, string) (net.Conn, error)
 
 	mu   sync.RWMutex // guards conn
 	conn serverConn


### PR DESCRIPTION
Doesn't rewrite much and maintains backwards compatibility.

Saw issues #25 and #28 and needed something along those lines. Wanted to add a context aware dialer but couldn't think of a way to do it cleanly and without more rewriting. However this should still cover those issues and my own case, since the function can close over anything it needs, including something that gives it a context, sets timeouts, etc.